### PR TITLE
Use 256-pixel VideoVAE tiles by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,10 +496,11 @@ aggressive point. The latter produced a coherent walking fox and repeated at
 8.02 seconds of DiT versus about 15.82 seconds natively. Native 256 uses the
 same-cost spatial-RoPE adaptation described above; it remains a fast composition
 preview rather than a substitute for a 512- or 768-class final render.
-The video VAE automatically chooses a 256-320 pixel spatial tile from the
-requested canvas geometry, minimizing repeated overlap work while keeping peak
-storage bounded. `H3_VAE_TILE_PIXELS=256` restores the original conservative
-tile plan for close-reference diagnosis.
+The video VAE defaults to a 256-pixel spatial tile and 64-pixel minimum
+overlap, matching the released checkpoint config. Set `H3_VAE_TILE_PIXELS`
+to a multiple of 16 from 256 through 512 to override the tile size for
+profiling. A value of 320 reproduces the previous automatic plan for the
+measured 576x1024 case.
 
 ### Weight residency and streamed prompt encoding
 

--- a/h3_video_vae.c
+++ b/h3_video_vae.c
@@ -663,7 +663,7 @@ static int tile_count_for_extent(int extent, int tile_pixels) {
     return count;
 }
 
-static int configured_tile_pixels(int pixel_height, int pixel_width) {
+static int configured_tile_pixels(void) {
     const char *value = getenv("H3_VAE_TILE_PIXELS");
     if (value && *value) {
         char *end = NULL;
@@ -671,22 +671,8 @@ static int configured_tile_pixels(int pixel_height, int pixel_width) {
         if (end && !*end && pixels >= TILE_PIXELS && pixels <= 512 &&
             pixels % SPATIAL_RATIO == 0) return (int)pixels;
     }
-    int best = TILE_PIXELS;
-    uint64_t best_score = UINT64_MAX;
-    for (int pixels = TILE_PIXELS; pixels <= 320;
-         pixels += SPATIAL_RATIO) {
-        uint64_t tiles = (uint64_t)tile_count_for_extent(pixel_height, pixels) *
-            (uint64_t)tile_count_for_extent(pixel_width, pixels);
-        /* The resident VAE is dominated by linears and activation traffic;
-         * measured tile cost follows area more closely than cubic sequence
-         * growth at these shapes. Attention is still included in each tile. */
-        uint64_t score = tiles * (uint64_t)pixels * (uint64_t)pixels;
-        if (score < best_score) {
-            best = pixels;
-            best_score = score;
-        }
-    }
-    return best;
+    /* Match vae_tile_size from the released checkpoint config. */
+    return TILE_PIXELS;
 }
 
 static int tile_axis_build(int extent, int tile_pixels, tile_axis *axis,
@@ -910,8 +896,7 @@ h3_video_vae_decoder *h3_video_vae_decoder_load(
     }
     decoder->latent_h = latent_height;
     decoder->latent_w = latent_width;
-    int tile_pixels = configured_tile_pixels(
-        latent_height * SPATIAL_RATIO, latent_width * SPATIAL_RATIO);
+    int tile_pixels = configured_tile_pixels();
     int ok = load_latent_normalization(
         weight_directory, decoder->latent_mean, decoder->latent_std,
         error, error_size) &&
@@ -1213,8 +1198,7 @@ int h3_video_vae_decode(const char *weight_directory,
     float latent_mean[LATENT_CHANNELS], latent_std[LATENT_CHANNELS];
     if (!load_latent_normalization(weight_directory, latent_mean, latent_std,
                                    error, error_size)) return 0;
-    int tile_pixels = configured_tile_pixels(
-        latent_height * SPATIAL_RATIO, latent_width * SPATIAL_RATIO);
+    int tile_pixels = configured_tile_pixels();
     if (latent_time == 2 &&
         (latent_height > TILE_PIXELS / SPATIAL_RATIO ||
          latent_width > TILE_PIXELS / SPATIAL_RATIO)) {


### PR DESCRIPTION
## Summary

Use 256-pixel VideoVAE tiles by default, matching `vae_tile_size` in the
released MiniMax-H3 config. This removes the geometry-based 256–320 default
search. Existing valid `H3_VAE_TILE_PIXELS` overrides remain unchanged.

## Reason

At 576x1024, the previous selector chooses 320-pixel tiles. In one Ref2VA
render decoded with that plan, the frames showed a visible 16-pixel grid.

Re-decoding the same saved post-denoising F32 latents with 256-pixel tiles
reduced the mean edge ratio at 16-pixel boundaries from 1.2385 to 1.1909
horizontally and from 1.1364 to 1.0890 vertically. The raw PPM and H.264
outputs remained close at 45.36 dB PSNR and 0.987 SSIM, so this comparison
did not indicate that H.264 introduced the grid.

## Tradeoff

For this 576x1024 decode on an M5 Max, the VAE took 95.13 seconds with
256-pixel tiles and 83.75 seconds with 320-pixel tiles. Peak live storage
was 9.37 GiB and 9.55 GiB, respectively. Other canvas geometries can produce
different tile-count and performance changes.

## Validation

- Built `h3`, `h3_tests`, `h3_semantic_vae_test`, and `h3_real_video_vae_test`.
- Passed 1,768 checks in the generic test suite.
- Completed a 576x1024 Ref2VA render with 124 frames and 20 denoising steps.
- Repeated the 256-versus-320 comparison from one saved latent artifact.
