### PR TITLE
Keep Video VAE RGB output finite for non-finite values

### DIFF
--- a/h3_video_vae.c
+++ b/h3_video_vae.c
@@ -623,8 +623,7 @@ static int unpack_frame_range(vae_context *vae, int first_frame,
                         (size_t)within_x);
                     float value = rows[patch * OUTPUT_PATCH + component] *
                                   deviation[channel] + mean[channel];
-                    if (value < 0.0f) value = 0.0f;
-                    if (value > 1.0f) value = 1.0f;
+                    value = fminf(fmaxf(value, 0.0f), 1.0f);
                     size_t destination = (((size_t)output_frame *
                         (size_t)pixel_h +
                         (size_t)y) * (size_t)pixel_w + (size_t)x) * 3 +

--- a/tests/test_real_video_vae.c
+++ b/tests/test_real_video_vae.c
@@ -26,8 +26,33 @@ static void progress(int completed, int total, void *opaque) {
                 completed, total);
 }
 
+static void test_nonfinite_output(const char *model_root) {
+    enum { LATENT_COUNT = 24 * 2, FRAME_COUNT = 3 * 5 * 16 * 16 };
+    float latent[LATENT_COUNT];
+    for (size_t index = 0; index < LATENT_COUNT; index++) latent[index] = NAN;
+    char weights[1024];
+    snprintf(weights, sizeof(weights), "%s/FL2VA/video_vae/source", model_root);
+    char error[512];
+    h3_video_frames got;
+    if (!h3_video_vae_decode(weights, "h3_shaders.metal", latent, 2, 1, 1,
+                             progress, NULL, &got, error, sizeof(error)))
+        die(error);
+    if (got.frames != 5 || got.height != 16 || got.width != 16)
+        die("non-finite visual decoder test returned the wrong shape");
+    for (size_t index = 0; index < FRAME_COUNT; index++)
+        if (!isfinite(got.rgb[index]) || got.rgb[index] < 0.0f ||
+            got.rgb[index] > 1.0f)
+            die("visual decoder returned RGB outside finite [0,1]");
+    h3_video_frames_free(&got);
+    puts("ok: visual decoder bounds non-finite RGB output");
+}
+
 int main(int argc, char **argv) {
     const char *model_root = argc > 1 ? argv[1] : "MiniMax-H3";
+    if (argc > 2 && !strcmp(argv[2], "--nonfinite-output")) {
+        test_nonfinite_output(model_root);
+        return 0;
+    }
     const char *latent_path = argc > 2 ? argv[2] :
         "misc/fixtures/h3_real_dit_denoise20_bf16.safetensors";
     const char *frame_path = argc > 3 ? argv[3] :


### PR DESCRIPTION
### Problem

`h3_video_frames.rgb` documents that decoded values are F32 in `[0,1]`, but
the Video VAE output boundary currently clamps with two ordered comparisons:

```c
if (value < 0.0f) value = 0.0f;
if (value > 1.0f) value = 1.0f;
```

Both comparisons are false for NaN, so a non-finite decoder value passes into
the returned RGB buffer unchanged. It can then propagate through tiled or
temporal blending and reach the final integer conversion.

### Change

Clamp the decoded value with `fminf(fmaxf(value, 0.0f), 1.0f)`. The standard
floating-point min/max behavior selects the finite operand when only one
operand is NaN, making the output mapping deterministic:

| Decoder value | Previous output | New output |
|---:|---:|---:|
| NaN | NaN | `0.0f` |
| `-INFINITY` | `0.0f` | `0.0f` |
| `+INFINITY` | `1.0f` | `1.0f` |

Finite values already inside `[0,1]` are unchanged, and ordinary out-of-range
values retain the existing saturation behavior.

### Regression coverage

The real Video VAE test now has a focused `--nonfinite-output` mode. It sends a
minimal `2x1x1` all-NaN latent through the public `h3_video_vae_decode` API and
checks that every returned RGB component is finite and within `[0,1]`.

Without the new clamp, the NaN output fails that contract check.

### Validation

- Strict Clang syntax checks pass for the production and regression-test files.
- A direct `fminf`/`fmaxf` probe returns `0.0` for NaN and negative infinity,
  and `1.0` for positive infinity.
- `git diff --check` passes.
