### PR TITLE
Avoid overflow when aligning large frame counts

### DIFF
--- a/h3.c
+++ b/h3.c
@@ -510,7 +510,8 @@ static int h3_valid_params(h3_ctx *ctx, const h3_params *params) {
             return 0;
         }
     }
-    if (params->frames < 5 || h3_align_frame_count(params->frames) > 362) {
+    int aligned_frames = h3_align_frame_count(params->frames);
+    if (params->frames < 5 || !aligned_frames || aligned_frames > 362) {
         h3_set_error(ctx, "frames must align within the released 5..362 range");
         return 0;
     }

--- a/h3_host.c
+++ b/h3_host.c
@@ -13,11 +13,11 @@ static const int h3_frame_per_token[5] = {1, 4, 4, 4, 4};
 static const double h3_frame_rescale = 5.0 / 3.0;
 
 int h3_align_frame_count(int requested) {
-    int value = requested < 5 ? 5 : requested;
-    int remainder = (value - 5) % 17;
+    int64_t value = requested < 5 ? 5 : requested;
+    int64_t remainder = (value - 5) % 17;
     if (remainder < 0) remainder += 17;
     if (remainder != 0) value += 17 - remainder;
-    return value;
+    return value > INT_MAX ? 0 : (int)value;
 }
 
 int h3_video_latent_t(int frame_count) {

--- a/h3_host.h
+++ b/h3_host.h
@@ -92,6 +92,7 @@ typedef struct {
     int has_spare;
 } h3_rng;
 
+/* Return the next legal frame count, or zero if it cannot fit in an int. */
 int h3_align_frame_count(int requested);
 int h3_video_latent_t(int frame_count);
 int h3_video_encoder_latent_t(int frame_count);

--- a/tests/test_h3.c
+++ b/tests/test_h3.c
@@ -37,6 +37,7 @@ static void test_temporal_and_canvas(void) {
         CHECK(got.video_t == cases[index].video_t);
         CHECK(got.audio_t == cases[index].audio_t);
     }
+    CHECK(h3_align_frame_count(INT32_MAX) == 0);
     CHECK(h3_video_encoder_latent_t(1) == 1);
     CHECK(h3_video_encoder_latent_t(5) == 2);
     CHECK(h3_video_encoder_latent_t(22) == 6);


### PR DESCRIPTION
## Problem

Frame requests are aligned upward to the next legal `5 + 17n` shape. The calculation currently uses signed `int` arithmetic even though CLI and library inputs can reach `INT32_MAX`.

For `INT32_MAX`, the required calculation is:

```text
remainder = (2147483647 - 5) % 17 = 3
increment = 17 - 3 = 14
aligned   = 2147483647 + 14 = 2147483661
```

The result cannot fit in an `int`. In an executed probe compiled from the upstream helper, it wrapped to `-2147483635` instead of producing a valid aligned count.

## Change

Perform the alignment arithmetic in `int64_t`. If the next legal frame count cannot be represented by the function's `int` return type, return zero as an explicit failure sentinel. Generation parameter validation now rejects that sentinel with the existing frame-range error.

Zero is unambiguous because every valid aligned frame count is at least 5.

## Regression coverage

The host test now checks that aligning `INT32_MAX` returns zero. The same probe compiled from the candidate helper returns zero, while the upstream helper fails that expectation.

## Validation

- actual-helper A/B probe: upstream `-2147483635`, candidate `0`
- strict C syntax checks for `h3.c` and `tests/test_h3.c` — passed
- `git diff --check` — passed
