### PR TITLE
Add continuous-generation and segment-concat scripts

### DIFF
--- a/concat_segments.sh
+++ b/concat_segments.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# concat_segments.sh — 按文件名自然排序拼接目录中的 segment_*.mp4 片段为单个视频。
+#
+# 用法：
+#   ./concat_segments.sh [选项] <片段目录> <输出.mp4>
+#
+# 选项：
+#   -r, --reencode  重编码兜底（libx264 + AAC）；默认 -c copy 无损拼接
+#   --help          显示本帮助
+#
+# 行为：按字典序（4 位零填充命名 = 自然序）收集片段；逐段 ffprobe 校验，
+#       损坏/缺失的片段跳过并打印警告；成功打印输出路径与总时长，
+#       失败删除不完整输出并以非零退出。
+#
+# 依赖：ffmpeg、ffprobe（零外部依赖，仅 bash 内建 + 上述工具）。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+REENCODE=0
+DIR=""
+OUT=""
+list=""
+trap 'rm -f "$list"' EXIT
+
+usage() {
+    cat >&2 <<'EOF'
+用法：./concat_segments.sh [选项] <片段目录> <输出.mp4>
+
+选项：
+  -r, --reencode  重编码兜底（libx264 + AAC）；默认 -c copy 无损拼接
+  --help          显示本帮助
+EOF
+}
+
+die() { echo "错误：$*" >&2; exit 1; }
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -r|--reencode) REENCODE=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        -*) die "未知选项：$1" ;;
+        *)
+            if [ -z "$DIR" ]; then
+                DIR="$1"
+            elif [ -z "$OUT" ]; then
+                OUT="$1"
+            else
+                die "多余的位置参数：$1"
+            fi
+            shift ;;
+    esac
+done
+
+[ -n "$DIR" ] || die "缺少 <片段目录> 参数"
+[ -n "$OUT" ] || die "缺少 <输出.mp4> 参数"
+[ -d "$DIR" ] || die "片段目录不存在：$DIR"
+
+segments=()
+for seg in "$DIR"/segment_*.mp4; do
+    [ -e "$seg" ] || continue
+    if ffprobe -v error "$seg" >/dev/null 2>&1; then
+        segments+=("$seg")
+    else
+        echo "警告：跳过损坏的片段 $seg"
+    fi
+done
+
+if [ "${#segments[@]}" -eq 0 ]; then
+    die "目录中没有有效的 segment_*.mp4 片段"
+fi
+
+echo "共 ${#segments[@]} 个有效片段，开始拼接："
+for seg in "${segments[@]}"; do
+    echo "  $seg"
+done
+
+# 转义路径供 ffconcat 脚本解析（ffmpeg av_get_token 规则：\X → X，
+# 空格是 token 终止符需转义；不用单引号包裹，否则引号段内的转义会失效）。
+# 逐字符处理，避免 bash 参数展开中反斜杠字面量语义的版本差异。
+escape_path() {
+    local s="$1" out="" c
+    while [ -n "$s" ]; do
+        c="${s%"${s#?}"}"
+        case "$c" in
+            \\ ) out="${out}\\\\" ;;   # \ → \\
+            \' ) out="${out}\'" ;;      # ' → \'
+            \  ) out="${out}\ " ;;      # 空格 → \<space>
+            *  ) out="${out}$c" ;;
+        esac
+        s="${s#?}"
+    done
+    printf '%s' "$out"
+}
+
+# concat list：绝对路径 + 转义。
+# 列表文件放在输出目录内（隐藏点文件，$$ 保证唯一），避免 /tmp 下被
+# 预置符号链接截断（TOCTOU）；退出时由 trap 清理。
+list="$DIR/.concat_list_$$.txt"
+: > "$list"
+for seg in "${segments[@]}"; do
+    abspath="$(cd "$(dirname "$seg")" && pwd)/$(basename "$seg")"
+    printf "file %s\n" "$(escape_path "$abspath")" >> "$list"
+done
+
+if [ "$REENCODE" -eq 1 ]; then
+    echo "模式：重编码（libx264 + AAC）"
+    if ! ffmpeg -y -v error -f concat -safe 0 -i "$list" \
+        -c:v libx264 -preset medium -crf 18 -c:a aac -b:a 128k "$OUT"; then
+        rm -f "$OUT"
+        die "ffmpeg 拼接失败，已删除不完整输出 $OUT"
+    fi
+else
+    echo "模式：-c copy 无损拼接"
+    if ! ffmpeg -y -v error -f concat -safe 0 -i "$list" -c copy "$OUT"; then
+        rm -f "$OUT"
+        die "ffmpeg 拼接失败，已删除不完整输出 $OUT"
+    fi
+fi
+
+dur="$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$OUT" 2>/dev/null || true)"
+echo "完成：$OUT"
+echo "总时长：${dur:-未知} 秒"

--- a/generate_series.sh
+++ b/generate_series.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+#
+# generate_series.sh — 从起始图片持续生成 15 秒视频片段，循环不断，Ctrl+C 停止。
+# 首段用 --first-frame 锚定起始图；后续段用 --ref-silent-video 参考上一段实现运动延续。
+#
+# 用法：
+#   ./generate_series.sh -i START.png -d OUTDIR -p "PROMPT" [选项...] [h3 透传参数...]
+#
+# 选项：
+#   -i IMG        起始图（必填；仅首段 --first-frame 使用）
+#   -d DIR        输出目录（必填；自动创建）
+#   -p TEXT       首段提示词（必填）
+#   -c TEXT       延续段提示词（默认 "Continue the motion in this clip."）
+#   -w N / -h N   宽 / 高（默认 512 / 512）
+#   -s N          去噪步数（默认 50）
+#   --frames N    每段帧数（默认 362；合法档位 5+17n）
+#   --layers N    DiT 层数（默认 50）
+#   --reuse N     denoiser reuse（默认 1）
+#   -r N          失败重试次数（默认 1；0 关闭重试）
+#   --help        显示本帮助
+#
+# 未识别的参数会原样透传给 h3（EXTRA_ARGS）。
+# 注意：EXTRA_ARGS 中不应出现 -o/--output（输出路径由本脚本管理）；
+#       透传 --core-reuse 时本脚本强制 --reuse 1（二者在 h3 中互斥）。
+#
+# 退出码：0 正常结束；1 生成失败中止（已完成片段保留）；130 被 Ctrl+C 中断。
+#
+# 依赖：./h3、ffmpeg、ffprobe（零外部依赖，仅 bash 内建 + 上述工具）。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+H3="$SCRIPT_DIR/h3"
+MODEL_DIR="$SCRIPT_DIR/MiniMax-H3"
+CONCAT="$SCRIPT_DIR/concat_segments.sh"
+
+IMG=""
+DIR=""
+FIRST_PROMPT=""
+CONT_PROMPT="Continue the motion in this clip."
+W=512
+H=512
+STEPS=50
+F=362
+L=50
+R=1
+RETRY=1
+EXTRA_ARGS=()
+
+usage() {
+    cat >&2 <<'EOF'
+用法：./generate_series.sh -i START.png -d OUTDIR -p "PROMPT" [选项...] [h3 透传参数...]
+
+选项：
+  -i IMG        起始图（必填；仅首段 --first-frame 使用）
+  -d DIR        输出目录（必填；自动创建）
+  -p TEXT       首段提示词（必填）
+  -c TEXT       延续段提示词（默认 "Continue the motion in this clip."）
+  -w N / -h N   宽 / 高（默认 512 / 512）
+  -s N          去噪步数（默认 50）
+  --frames N    每段帧数（默认 362；合法档位 5+17n）
+  --layers N    DiT 层数（默认 50）
+  --reuse N     denoiser reuse（默认 1）
+  -r N          失败重试次数（默认 1；0 关闭重试）
+  --help        显示本帮助
+EOF
+}
+
+die() { echo "错误：$*" >&2; exit 1; }
+
+fail_usage() {
+    echo "错误：$*" >&2
+    usage
+    exit 1
+}
+
+is_digits() { case "$1" in ''|*[!0-9]*) return 1;; *) return 0;; esac; }
+
+# ---- 手写参数解析：支持 -k value、-k=value、--key value、--key=value ----
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -i) [ "$#" -ge 2 ] || die "选项 -i 缺少参数"; IMG="$2"; shift 2 ;;
+        -i=*) IMG="${1#-i=}"; shift ;;
+        -d) [ "$#" -ge 2 ] || die "选项 -d 缺少参数"; DIR="$2"; shift 2 ;;
+        -d=*) DIR="${1#-d=}"; shift ;;
+        -p) [ "$#" -ge 2 ] || die "选项 -p 缺少参数"; FIRST_PROMPT="$2"; shift 2 ;;
+        -p=*) FIRST_PROMPT="${1#-p=}"; shift ;;
+        -c) [ "$#" -ge 2 ] || die "选项 -c 缺少参数"; CONT_PROMPT="$2"; shift 2 ;;
+        -c=*) CONT_PROMPT="${1#-c=}"; shift ;;
+        -w) [ "$#" -ge 2 ] || die "选项 -w 缺少参数"; W="$2"; shift 2 ;;
+        -w=*) W="${1#-w=}"; shift ;;
+        -h) [ "$#" -ge 2 ] || die "选项 -h 缺少参数"; H="$2"; shift 2 ;;
+        -h=*) H="${1#-h=}"; shift ;;
+        -s) [ "$#" -ge 2 ] || die "选项 -s 缺少参数"; STEPS="$2"; shift 2 ;;
+        -s=*) STEPS="${1#-s=}"; shift ;;
+        -r) [ "$#" -ge 2 ] || die "选项 -r 缺少参数"; RETRY="$2"; shift 2 ;;
+        -r=*) RETRY="${1#-r=}"; shift ;;
+        --frames) [ "$#" -ge 2 ] || die "选项 --frames 缺少参数"; F="$2"; shift 2 ;;
+        --frames=*) F="${1#--frames=}"; shift ;;
+        --layers) [ "$#" -ge 2 ] || die "选项 --layers 缺少参数"; L="$2"; shift 2 ;;
+        --layers=*) L="${1#--layers=}"; shift ;;
+        --reuse) [ "$#" -ge 2 ] || die "选项 --reuse 缺少参数"; R="$2"; shift 2 ;;
+        --reuse=*) R="${1#--reuse=}"; shift ;;
+        --help) usage; exit 0 ;;
+        --) shift; EXTRA_ARGS+=("$@"); break ;;
+        *) EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
+
+# ---- 校验必填项与数值 ----
+[ -n "$IMG" ] || fail_usage "缺少必填参数 -i（起始图）"
+[ -n "$DIR" ] || fail_usage "缺少必填参数 -d（输出目录）"
+[ -n "$FIRST_PROMPT" ] || fail_usage "缺少必填参数 -p（首段提示词）"
+[ -f "$IMG" ] || die "起始图不存在：$IMG"
+
+for v in "$W" "$H" "$STEPS" "$F" "$L" "$R"; do
+    is_digits "$v" || die "非法数值：$v"
+done
+is_digits "$RETRY" || die "非法重试次数：$RETRY"
+
+# ---- EXTRA_ARGS 校验：不允许 -o/--output；--core-reuse 强制 --reuse 1 ----
+i=0
+while [ "$i" -lt "${#EXTRA_ARGS[@]}" ]; do
+    case "${EXTRA_ARGS[$i]}" in
+        -o|-o=*|-o?*|--output|--output=*)
+            die "EXTRA_ARGS 中不允许出现 -o/--output（输出路径由脚本管理）" ;;
+        --core-reuse|--core-reuse=*)
+            R=1
+            echo "注意：检测到 --core-reuse 透传，已强制 --reuse 1（二者在 h3 中互斥）" ;;
+    esac
+    i=$((i+1))
+done
+
+[ -x "$H3" ] || die "找不到可执行的 h3：$H3"
+[ -d "$MODEL_DIR" ] || die "模型目录不存在：$MODEL_DIR"
+
+mkdir -p "$DIR"
+
+# ---- 中断处理：置标志 + 兜底 kill 当前 h3 子进程 ----
+INTERRUPTED=0
+H3_PID=""
+trap 'INTERRUPTED=1; [ -n "${H3_PID:-}" ] && kill "$H3_PID" 2>/dev/null' INT
+
+# ---- 续跑：校验既有 segment_*.mp4，损坏删除并警告，next=最大有效编号+1 ----
+max=0
+for seg in "$DIR"/segment_*.mp4; do
+    [ -e "$seg" ] || continue
+    base="$(basename "$seg")"
+    num="${base#segment_}"
+    num="${num%.mp4}"
+    if ! is_digits "$num"; then
+        echo "警告：无法识别编号的片段 ${base}，已删除"
+        rm -f "$seg"
+        continue
+    fi
+    if ffprobe -v error "$seg" >/dev/null 2>&1; then
+        [ "$num" -gt "$max" ] && max="$num"
+    else
+        echo "警告：损坏的片段 ${base}，已删除"
+        rm -f "$seg"
+    fi
+done
+next=$((max + 1))
+if [ "$max" -gt 0 ]; then
+    echo "续跑：最高有效片段编号为 ${max}，将从 segment_$(printf %04d "$next").mp4 继续"
+fi
+
+# ---- 主循环：持续生成，Ctrl+C 停止 ----
+while [ "$INTERRUPTED" -ne 1 ]; do
+    if [ "$next" -eq 1 ]; then
+        ref_args=(--first-frame "$IMG")
+        prompt="$FIRST_PROMPT"
+        echo "[1] prompt=${prompt}（预计约 30.5 分钟：加载 30s + 生成 ~30min）"
+    else
+        ref_args=(--ref-silent-video "$DIR/segment_$(printf %04d $((next-1))).mp4")
+        prompt="$CONT_PROMPT"
+        echo "[$next] prompt=${prompt}（预计约 32 分钟：加载 30s + 参考编码 82s + 生成 ~30min）"
+    fi
+    out="$DIR/segment_$(printf %04d "$next").mp4"
+    rc=1
+    for ((attempt=0; attempt<=RETRY; attempt++)); do
+        [ "$INTERRUPTED" -eq 1 ] && break          # h3 启动前查中断
+        echo "[$next] 第 $((attempt+1))/$((RETRY+1)) 次尝试：h3 生成中..."
+        "$H3" -d "$MODEL_DIR" -p "$prompt" --width "$W" --height "$H" \
+            --frames "$F" --steps "$STEPS" --layers "$L" --reuse "$R" \
+            "${ref_args[@]}" -o "$out" "${EXTRA_ARGS[@]}" &
+        H3_PID="$!"
+        if wait "$H3_PID"; then
+            rc=0
+        else
+            rc=$?
+        fi
+        H3_PID=""
+        [ "$INTERRUPTED" -eq 1 ] && break          # Ctrl+C：不再重试
+        if [ "$rc" -eq 0 ] && ffprobe -v error "$out" >/dev/null 2>&1; then
+            echo "[$next] 完成：$out"
+            break
+        fi
+        [ "$INTERRUPTED" -eq 1 ] && break          # 校验窗口被中断：不 rm，交由收尾判定
+        rm -f "$out"
+        if [ "$rc" -ne 0 ]; then
+            echo "[$next] 第 $((attempt+1)) 次失败：h3 退出码 $rc"
+        else
+            echo "[$next] 第 $((attempt+1)) 次失败：ffprobe 校验不通过"
+        fi
+        rc=1
+    done
+    [ "$INTERRUPTED" -eq 1 ] && break              # 中断收尾，不进下一段
+    if [ "$rc" -ne 0 ]; then
+        echo "中止：segment_$(printf %04d "$next") 失败，已完成 $((next-1)) 段"
+        exit 1
+    fi
+    next=$((next+1))
+done
+
+# ---- Ctrl+C 收尾：校验当前段，清理不完整文件，打印保留片段与拼接提示 ----
+cur="$DIR/segment_$(printf %04d "$next").mp4"
+if [ -f "$cur" ]; then
+    if ffprobe -v error "$cur" >/dev/null 2>&1; then
+        echo "中断收尾：$cur 完整，保留"
+    else
+        echo "中断收尾：删除不完整片段 $cur"
+        rm -f "$cur"
+    fi
+fi
+echo
+echo "已中断。当前保留的有效片段："
+n=0
+for seg in "$DIR"/segment_*.mp4; do
+    [ -e "$seg" ] || continue
+    if ffprobe -v error "$seg" >/dev/null 2>&1; then
+        echo "  $seg"
+        n=$((n+1))
+    else
+        echo "  （忽略损坏）$seg"
+    fi
+done
+[ "$n" -eq 0 ] && echo "  （无）"
+echo
+echo "拼接所有片段为一个视频："
+echo "  $CONCAT \"$DIR\" \"$DIR/final.mp4\""
+exit 130

--- a/tests/sigint_helper.py
+++ b/tests/sigint_helper.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+sigint_helper.py — 测试辅助：以非异步方式启动一个命令（使其 SIGINT 可被 trap），
+轮询触发文件出现后向它发送 SIGINT，并记录退出码。
+
+背景：从 shell 用 `&` 启动的后台脚本会被 bash 忽略 SIGINT，无法测试 Ctrl+C 收尾；
+通过 Python fork+exec 启动则继承默认信号处置，脚本内的 `trap ... INT` 正常工作。
+
+用法：
+  sigint_helper.py [选项] [KEY=VALUE ...] -- CMD [ARGS ...]
+
+选项：
+  --cwd DIR       子进程工作目录（默认当前目录）
+  --log FILE      子进程 stdout+stderr 重定向到 FILE
+  --trigger FILE  该文件出现时向子进程发送 SIGINT（测试用 touch 触发）
+  --exitfile FILE 子进程退出码写入该文件；timeout 时写入字符串 "timeout"
+  --pidfile FILE  子进程 PID 写入该文件
+  --timeout S     超时秒数（默认 60；超时 SIGKILL 子进程并写 "timeout"）
+"""
+
+import os
+import signal
+import sys
+import time
+
+# 后台启动的进程会从 shell 继承 SIGINT=SIG_IGN（job control 关闭时 bash 对
+# 异步命令置 IGN），这会让子脚本的 `trap INT` 失效。这里强制恢复默认处置，
+# 使 fork 出的子进程可正常收到 SIGINT 并触发 trap。
+signal.signal(signal.SIGINT, signal.SIG_DFL)
+signal.signal(signal.SIGQUIT, signal.SIG_DFL)
+
+argv = sys.argv[1:]
+
+def parse_args(argv):
+    opts = {"cwd": ".", "log": None, "trigger": None,
+            "exitfile": None, "pidfile": None, "timeout": 60.0}
+    envs = {}
+    cmd = None
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a in ("--cwd", "--log", "--trigger", "--exitfile", "--pidfile", "--timeout"):
+            opts[a[2:]] = argv[i + 1]
+            i += 2
+        elif a == "--":
+            cmd = argv[i + 1:]
+            break
+        elif "=" in a and not a.startswith("--"):
+            k, v = a.split("=", 1)
+            envs[k] = v
+            i += 1
+        else:
+            raise SystemExit("bad arg: %s" % a)
+    if not cmd:
+        raise SystemExit("missing -- CMD")
+    if opts["timeout"]:
+        opts["timeout"] = float(opts["timeout"])
+    return opts, envs, cmd
+
+opts, envs, cmd = parse_args(argv)
+
+env = dict(os.environ)
+env.update(envs)
+
+pid = os.fork()
+if pid == 0:
+    # child：新建会话/进程组，超时清理可用 killpg 整组终止，避免孤儿进程
+    try:
+        os.setsid()
+    except OSError:
+        pass
+    if opts["log"]:
+        try:
+            fd = os.open(opts["log"], os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+            os.dup2(fd, 1)
+            os.dup2(fd, 2)
+            os.close(fd)
+        except OSError:
+            pass
+    try:
+        os.chdir(opts["cwd"])
+    except OSError:
+        os._exit(126)
+    # 兜底：确保子进程 SIGINT 为默认处置（SIG_IGN 会在 exec 后保留）
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    signal.signal(signal.SIGQUIT, signal.SIG_DFL)
+    try:
+        os.execvpe(cmd[0], cmd, env)
+    except OSError:
+        os._exit(127)
+
+if opts["pidfile"]:
+    with open(opts["pidfile"], "w") as f:
+        f.write(str(pid))
+
+def write_exit(code):
+    if opts["exitfile"]:
+        with open(opts["exitfile"], "w") as f:
+            f.write(str(code))
+
+def cleanup_group():
+    """best-effort 清扫：子进程（会话 leader）已退出后，组内残余孙进程（如
+    mock h3 的 sleep）仍可能存活到自然结束，这里整组 SIGKILL 避免孤儿。"""
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except (ProcessLookupError, OSError):
+        pass
+
+
+deadline = time.time() + opts["timeout"]
+while True:
+    try:
+        rpid, st = os.waitpid(pid, os.WNOHANG)
+    except ChildProcessError:
+        cleanup_group()
+        write_exit("gone")
+        sys.exit(0)
+    if rpid == pid:
+        code = os.waitstatus_to_exitcode(st) if hasattr(os, "waitstatus_to_exitcode") else (st >> 8)
+        cleanup_group()
+        write_exit(code)
+        sys.exit(0)
+    if opts["trigger"] and os.path.exists(opts["trigger"]):
+        break
+    if time.time() > deadline:
+        try:
+            os.killpg(pid, signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            pass
+        write_exit("timeout")
+        sys.exit(2)
+    time.sleep(0.05)
+
+# 触发文件出现：发送 SIGINT（模拟 Ctrl+C），然后等待子进程退出（带超时）
+try:
+    os.kill(pid, signal.SIGINT)
+except ProcessLookupError:
+    pass
+
+wait_deadline = time.time() + 15.0
+while True:
+    try:
+        rpid, st = os.waitpid(pid, os.WNOHANG)
+    except ChildProcessError:
+        cleanup_group()
+        write_exit("gone")
+        sys.exit(0)
+    if rpid == pid:
+        code = os.waitstatus_to_exitcode(st) if hasattr(os, "waitstatus_to_exitcode") else (st >> 8)
+        cleanup_group()
+        write_exit(code)
+        sys.exit(0)
+    if time.time() > wait_deadline:
+        try:
+            os.killpg(pid, signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            pass
+        write_exit("sigkill")
+        sys.exit(3)
+    time.sleep(0.1)

--- a/tests/test_continuous_generation.sh
+++ b/tests/test_continuous_generation.sh
@@ -1,0 +1,423 @@
+#!/usr/bin/env bash
+#
+# test_continuous_generation.sh — generate_series.sh / concat_segments.sh 的测试。
+# 需要 PATH 中的 ffmpeg / ffprobe（本仓库生成链路本来就依赖它们），以及 python3。
+# 用法：bash tests/test_continuous_generation.sh
+#
+# 覆盖：语法、无参数用法、mock h3 下的生成/中断/重试/续跑/透传参数、
+#       concat 无损拼接 / 重编码 / 损坏跳过。
+#
+# 说明：generate_series.sh 是无限循环，测试通过 tests/sigint_helper.py 模拟
+#       Ctrl+C（真实后台 shell 会忽略 SIGINT，故用 python fork 启动脚本）。
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GS="$ROOT/generate_series.sh"
+CS="$ROOT/concat_segments.sh"
+HELPER="$ROOT/tests/sigint_helper.py"
+
+command -v python3 >/dev/null 2>&1 || { echo "需要 python3" >&2; exit 1; }
+command -v ffmpeg >/dev/null 2>&1 || { echo "需要 ffmpeg" >&2; exit 1; }
+command -v ffprobe >/dev/null 2>&1 || { echo "需要 ffprobe" >&2; exit 1; }
+
+TMP="${TMPDIR:-/tmp}/h3_script_tests_$$"
+rm -rf "$TMP"
+mkdir -p "$TMP"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS=0
+FAIL=0
+ok()  { PASS=$((PASS+1)); printf 'ok   - %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf 'FAIL - %s\n' "$1"; }
+
+check() { # check <desc> <cmd...>
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then ok "$desc"; else bad "$desc"; fi
+}
+
+# 生成一个真实的极小 mp4 片段（16x16，0.1s，与 mock h3 使用相同参数）
+mkseg() {
+    ffmpeg -y -v error -f lavfi -i color=c=black:s=16x16:d=0.1 \
+        -c:v libx264 -pix_fmt yuv420p -an "$1"
+}
+
+dur() { ffprobe -v error -show_entries format=duration -of csv=p=0 "$1" 2>/dev/null || echo 0; }
+
+# approx <actual> <expected> <tolerance>：浮点容差比较
+approx() {
+    awk -v a="$1" -v e="$2" -v t="$3" \
+        'BEGIN { d = a - e; if (d < 0) d = -d; exit !(d <= t) }'
+}
+
+# 生成 mock h3：从命令行提取 -o 输出路径，写一个真实极小 mp4；
+# 通过环境变量模拟失败 / 延迟 / 损坏 / 记录参数。
+make_mock_h3() {
+    local dir="$1"
+    mkdir -p "$dir/MiniMax-H3"
+    cat > "$dir/h3" <<'MOCKEOF'
+#!/usr/bin/env bash
+if [ -n "${MOCK_LOG:-}" ]; then
+    printf '%s\n' "$*" >> "$MOCK_LOG"
+fi
+out=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o|--output) out="$2"; shift 2 ;;
+        -d|--model-dir|-p|--prompt|--first-frame|--ref-silent-video) shift 2 ;;
+        --width=*|--height=*|--frames=*|--steps=*|--layers=*|--reuse=*) shift ;;
+        *) shift ;;
+    esac
+done
+[ -n "$out" ] || { echo "mock: missing -o" >&2; exit 2; }
+base="$(basename "$out")"; num="${base#segment_}"; num="${num%.mp4}"
+
+delay=0
+if [ -n "${MOCK_DELAY_FROM:-}" ]; then
+    [ "${MOCK_DELAY_FROM:-999999}" -le "$num" ] && delay="${MOCK_DELAY:-30}"
+elif [ "${MOCK_DELAY:-0}" -gt 0 ]; then
+    delay="$MOCK_DELAY"
+fi
+
+# 指定编号起先写损坏文件再长睡，模拟"写到一半被中断"
+if [ -n "${MOCK_CORRUPT_FROM:-}" ] && [ "${MOCK_CORRUPT_FROM:-999999}" -le "$num" ]; then
+    printf 'not-a-real-mp4-garbage' > "$out"
+    sleep "${MOCK_CORRUPT_DELAY:-${MOCK_DELAY:-30}}"
+    echo "mock: wrote corrupt file" >&2
+    exit 0
+fi
+
+# 指定编号起先写完整有效文件再长睡，模拟"h3 已写完但进程未退出时被中断"
+if [ -n "${MOCK_HOLD_FROM:-}" ] && [ "${MOCK_HOLD_FROM:-999999}" -le "$num" ]; then
+    ffmpeg -y -v error -f lavfi -i color=c=black:s=16x16:d=0.1 \
+        -c:v libx264 -pix_fmt yuv420p -an "$out"
+    sleep "${MOCK_HOLD_DELAY:-30}"
+    echo "mock: held after writing valid file" >&2
+    exit 0
+fi
+
+if [ "${MOCK_FAIL_ALWAYS:-0}" = "1" ]; then
+    echo "mock: forced failure" >&2; exit 1
+fi
+if [ "${MOCK_FAIL_ONCE:-0}" = "1" ] && [ ! -e "${MOCK_FAIL_MARKER:-}" ]; then
+    touch "${MOCK_FAIL_MARKER:-}"
+    echo "mock: simulated first-attempt failure" >&2; exit 1
+fi
+
+[ "$delay" -gt 0 ] && sleep "$delay"
+ffmpeg -y -v error -f lavfi -i color=c=black:s=16x16:d=0.1 \
+    -c:v libx264 -pix_fmt yuv420p -an "$out"
+MOCKEOF
+    chmod +x "$dir/h3"
+}
+
+# 等待文件出现，超时 N 秒
+wait_file() { # wait_file <path> <seconds>
+    local path="$1" secs="$2" i
+    for ((i = 0; i < secs * 5; i++)); do
+        [ -f "$path" ] && return 0
+        sleep 0.2
+    done
+    return 1
+}
+
+# 等待文件包含某模式，超时 N 秒
+wait_grep() { # wait_grep <file> <pattern> <seconds>
+    local file="$1" pat="$2" secs="$3" i
+    for ((i = 0; i < secs * 10; i++)); do
+        grep -q "$pat" "$file" 2>/dev/null && return 0
+        sleep 0.1
+    done
+    return 1
+}
+
+# 通过 sigint_helper.py 后台启动 generate_series.sh（模拟 Ctrl+C 需后台 + 触发文件）。
+# 用法：run_gen <wd> <prefix> <timeout> -- <env...> -- <script args...>
+# 之后：touch $TMP/<prefix>.trigger 发送 Ctrl+C；wait_gen <prefix> <secs> 等待结束。
+run_gen() {
+    local wd="$1" prefix="$2" timeout="$3"; shift 3
+    local envargs=()
+    local scriptargs=()
+    local mode=env
+    for a in "$@"; do
+        if [ "$a" = "--" ]; then mode=script; continue; fi
+        if [ "$mode" = env ]; then envargs+=("$a"); else scriptargs+=("$a"); fi
+    done
+    python3 "$HELPER" --cwd "$wd" --log "$wd/gen.log" \
+        --trigger "$TMP/$prefix.trigger" --exitfile "$TMP/$prefix.exit" \
+        --pidfile "$TMP/$prefix.pid" --timeout "$timeout" \
+        "${envargs[@]}" -- ./generate_series.sh "${scriptargs[@]}" &
+    echo "$!" > "$TMP/$prefix.hpid"
+}
+
+wait_gen() { # wait_gen <prefix> <seconds>
+    local prefix="$1" secs="$2" i
+    local hpid
+    hpid="$(cat "$TMP/$prefix.hpid" 2>/dev/null)"
+    for ((i = 0; i < secs * 10; i++)); do
+        if [ -f "$TMP/$prefix.exit" ]; then
+            [ -n "$hpid" ] && wait "$hpid" 2>/dev/null || true
+            return 0
+        fi
+        if [ -n "$hpid" ] && ! kill -0 "$hpid" 2>/dev/null; then
+            return 1
+        fi
+        sleep 0.1
+    done
+    # 超时：终止 helper（若仍在），避免无限等待
+    if [ -n "$hpid" ] && kill -0 "$hpid" 2>/dev/null; then
+        kill "$hpid" 2>/dev/null || true
+        wait "$hpid" 2>/dev/null || true
+    fi
+    return 1
+}
+
+gen_exit() { cat "$TMP/$1.exit" 2>/dev/null; }
+
+printf '%s\n' "== 1. 语法与基础校验 =="
+
+check "bash -n generate_series.sh" bash -n "$GS"
+check "bash -n concat_segments.sh" bash -n "$CS"
+check "bash -n tests/test_continuous_generation.sh" bash -n "$0"
+check "生成脚本可执行" test -x "$GS"
+check "拼接脚本可执行" test -x "$CS"
+
+out="$(bash "$GS" 2>&1)" || true
+printf '%s' "$out" | grep -q '用法' \
+    && ok "无参数时打印用法" || bad "无参数时打印用法"
+bash "$GS" >/dev/null 2>&1
+[ "$?" -ne 0 ] && ok "无参数时以非零退出" || bad "无参数时以非零退出"
+
+printf '%s\n' "== 2. generate_series.sh：连续生成 + 中断 =="
+
+# 首两段快速生成，第 3 段先写损坏文件再长睡，便于验证中断后清理该不完整段
+WD="$TMP/basic"; mkdir -p "$WD/out"; printf 'fake-png' > "$WD/start.png"
+make_mock_h3 "$WD"; cp "$GS" "$WD/"
+LOG="$WD/h3.log"
+run_gen "$WD" basic 40 \
+    MOCK_CORRUPT_FROM=3 MOCK_CORRUPT_DELAY=30 MOCK_LOG="$LOG" \
+    -- -i start.png -d out -p "PROMPT" -c "CONT" -w 512 -h 512 \
+    --steps 2 --frames 5 --seed 7
+wait_file "$WD/out/segment_0002.mp4" 20 || bad "segment_0002 未生成"
+sleep 1
+: > "$TMP/basic.trigger"
+wait_gen basic 25
+
+[ "$(gen_exit basic)" = "130" ] \
+    && ok "中断后退出码 130（rc=$(gen_exit basic)）" || bad "中断后退出码 130（rc=$(gen_exit basic)）"
+ffprobe -v error "$WD/out/segment_0001.mp4" >/dev/null 2>&1 \
+    && ok "segment_0001 完整保留" || bad "segment_0001 完整保留"
+ffprobe -v error "$WD/out/segment_0002.mp4" >/dev/null 2>&1 \
+    && ok "segment_0002 完整保留" || bad "segment_0002 完整保留"
+[ -f "$WD/out/segment_0003.mp4" ] \
+    && bad "被中断的 segment_0003（已写入损坏文件）应被删除" \
+    || ok "被中断的 segment_0003（已写入损坏文件）已删除"
+grep -q '中断收尾：删除不完整片段' "$WD/gen.log" \
+    && ok "中断收尾删除写入一半的片段" || bad "中断收尾删除写入一半的片段"
+
+grep -q '^\[1\] prompt=PROMPT' "$WD/gen.log" \
+    && ok "首段日志显示首段提示词" || bad "首段日志显示首段提示词"
+grep -q '^\[2\] prompt=CONT' "$WD/gen.log" \
+    && ok "第 2 段日志显示延续提示词 CONT" || bad "第 2 段日志显示延续提示词"
+grep -q '预计约 30.5 分钟' "$WD/gen.log" \
+    && ok "首段打印预计耗时（30.5 分钟）" || bad "首段打印预计耗时"
+grep -q '预计约 32 分钟' "$WD/gen.log" \
+    && ok "后续段打印预计耗时（32 分钟）" || bad "后续段打印预计耗时"
+grep -q -- '--first-frame start.png' "$LOG" \
+    && ok "首段使用 --first-frame 锚定起始图" || bad "首段使用 --first-frame"
+grep -q -- '--ref-silent-video out/segment_0001.mp4' "$LOG" \
+    && ok "第 2 段使用 --ref-silent-video 参考上一段" || bad "第 2 段使用 --ref-silent-video"
+grep -q -- '--seed 7' "$LOG" \
+    && ok "EXTRA_ARGS 透传 --seed 7 生效" || bad "EXTRA_ARGS 透传 --seed 7"
+grep -q 'concat_segments.sh' "$WD/gen.log" \
+    && ok "中断收尾打印拼接命令提示" || bad "中断收尾打印拼接命令提示"
+grep -q '已中断。当前保留的有效片段' "$WD/gen.log" \
+    && ok "中断收尾列出保留片段" || bad "中断收尾列出保留片段"
+
+printf '%s\n' "== 3. generate_series.sh：中断时清理不完整片段 =="
+
+# 第 2 段 mock 先写垃圾文件再长睡 → 中断时脚本应删除该不完整片段
+WD="$TMP/interrupt"; mkdir -p "$WD/out"; printf 'fake-png' > "$WD/start.png"
+make_mock_h3 "$WD"; cp "$GS" "$WD/"
+LOG="$WD/h3.log"
+run_gen "$WD" interrupt 40 \
+    MOCK_CORRUPT_FROM=2 MOCK_CORRUPT_DELAY=30 MOCK_LOG="$LOG" \
+    -- -i start.png -d out -p "PROMPT" -c "CONT" --steps 2 --frames 5
+wait_file "$WD/out/segment_0001.mp4" 20 || bad "interrupt: segment_0001 未生成"
+sleep 1.5   # 让第 2 段 mock 写入垃圾文件并进入长睡
+: > "$TMP/interrupt.trigger"
+wait_gen interrupt 25
+
+[ "$(gen_exit interrupt)" = "130" ] \
+    && ok "中断清理场景退出码 130" || bad "中断清理场景退出码（rc=$(gen_exit interrupt)）"
+ffprobe -v error "$WD/out/segment_0001.mp4" >/dev/null 2>&1 \
+    && ok "中断清理后 segment_0001 保留" || bad "中断清理后 segment_0001 保留"
+[ -f "$WD/out/segment_0002.mp4" ] \
+    && bad "不完整的 segment_0002 应被删除" || ok "不完整的 segment_0002 已删除"
+grep -q '中断收尾：删除不完整片段' "$WD/gen.log" \
+    && ok "打印删除不完整片段提示" || bad "打印删除不完整片段提示"
+
+printf '%s\n' "== 4. generate_series.sh：校验窗口内不误删（完整片段保留）=="
+
+# 第 2 段 mock 写完完整有效文件后进程未退出（模拟校验窗口），
+# 此时中断 → 收尾 ffprobe 校验通过，应保留该完整片段
+WD="$TMP/hold"; mkdir -p "$WD/out"; printf 'fake-png' > "$WD/start.png"
+make_mock_h3 "$WD"; cp "$GS" "$WD/"
+LOG="$WD/h3.log"
+run_gen "$WD" hold 40 \
+    MOCK_HOLD_FROM=2 MOCK_HOLD_DELAY=30 MOCK_LOG="$LOG" \
+    -- -i start.png -d out -p "PROMPT" -c "CONT" --steps 2 --frames 5
+wait_file "$WD/out/segment_0001.mp4" 20 || bad "hold: segment_0001 未生成"
+sleep 1.5   # 第 2 段 mock 写完有效文件并进入长睡
+: > "$TMP/hold.trigger"
+wait_gen hold 25
+
+[ "$(gen_exit hold)" = "130" ] \
+    && ok "校验窗口中断退出码 130" || bad "校验窗口中断退出码（rc=$(gen_exit hold)）"
+ffprobe -v error "$WD/out/segment_0002.mp4" >/dev/null 2>&1 \
+    && ok "校验窗口内已完成的 segment_0002 保留" || bad "校验窗口内已完成的 segment_0002 保留"
+grep -q '中断收尾：.*完整，保留' "$WD/gen.log" \
+    && ok "打印保留完整片段提示" || bad "打印保留完整片段提示"
+
+printf '%s\n' "== 5. generate_series.sh：失败重试 / 不重试 =="
+
+# -r 1：首段第一次失败，重试成功
+WD="$TMP/retry"; mkdir -p "$WD/out"; printf 'fake-png' > "$WD/start.png"
+make_mock_h3 "$WD"; cp "$GS" "$WD/"
+LOG="$WD/h3.log"; MARK="$WD/fail.marker"
+run_gen "$WD" retry 40 \
+    MOCK_FAIL_ONCE=1 MOCK_FAIL_MARKER="$MARK" MOCK_LOG="$LOG" \
+    MOCK_DELAY_FROM=3 MOCK_DELAY=30 \
+    -- -i start.png -d out -p "PROMPT" -r 1 --steps 2 --frames 5
+wait_file "$WD/out/segment_0002.mp4" 20 || bad "重试后应连续生成到 0002"
+sleep 1
+: > "$TMP/retry.trigger"
+wait_gen retry 25
+
+[ "$(gen_exit retry)" = "130" ] \
+    && ok "重试场景中断退出码 130" || bad "重试场景中断退出码（rc=$(gen_exit retry)）"
+grep -q '第 1 次失败：h3 退出码' "$WD/gen.log" \
+    && ok "记录第一次失败警告" || bad "记录第一次失败警告"
+ffprobe -v error "$WD/out/segment_0001.mp4" >/dev/null 2>&1 \
+    && ok "重试后 segment_0001 有效" || bad "重试后 segment_0001 有效"
+
+# -r 0：失败立即中止，不重试，退出码 1
+WD="$TMP/noretry"; mkdir -p "$WD/out"; printf 'fake-png' > "$WD/start.png"
+make_mock_h3 "$WD"; cp "$GS" "$WD/"
+LOG="$WD/h3.log"
+run_gen "$WD" noretry 30 \
+    MOCK_FAIL_ALWAYS=1 MOCK_LOG="$LOG" \
+    -- -i start.png -d out -p "PROMPT" -r 0 --steps 2 --frames 5
+wait_gen noretry 15
+
+[ "$(gen_exit noretry)" = "1" ] \
+    && ok "-r 0 失败立即中止（rc=$(gen_exit noretry)）" || bad "-r 0 失败立即中止（rc=$(gen_exit noretry)）"
+grep -q '中止：' "$WD/gen.log" && ok "打印中止信息" || bad "打印中止信息"
+[ -z "$(ls "$WD/out" 2>/dev/null)" ] \
+    && ok "失败后无残留片段" || bad "失败后无残留片段"
+
+printf '%s\n' "== 6. generate_series.sh：续跑 + 启动扫描 =="
+
+# 预置损坏 segment_0001 + 有效 segment_0002 → 删除损坏，从 0003 续跑，ref=0002
+WD="$TMP/resume"; mkdir -p "$WD/out"; printf 'fake-png' > "$WD/start.png"
+make_mock_h3 "$WD"; cp "$GS" "$WD/"
+printf 'garbage-not-mp4' > "$WD/out/segment_0001.mp4"
+mkseg "$WD/out/segment_0002.mp4"
+LOG="$WD/h3.log"
+run_gen "$WD" resume 40 \
+    MOCK_CORRUPT_FROM=3 MOCK_CORRUPT_DELAY=30 MOCK_LOG="$LOG" \
+    -- -i start.png -d out -p "PROMPT" --steps 2 --frames 5
+wait_grep "$LOG" 'segment_0003.mp4' 20 || bad "续跑应从 0003 开始"
+sleep 1
+: > "$TMP/resume.trigger"
+wait_gen resume 25
+
+[ "$(gen_exit resume)" = "130" ] \
+    && ok "续跑场景中断退出码 130" || bad "续跑场景中断退出码（rc=$(gen_exit resume)）"
+grep -q '警告：损坏的片段 segment_0001.mp4' "$WD/gen.log" \
+    && ok "启动时警告损坏片段" || bad "启动时警告损坏片段"
+[ -f "$WD/out/segment_0001.mp4" ] \
+    && bad "损坏片段应被删除" || ok "损坏片段已删除"
+grep -q '续跑：最高有效片段编号为 0002' "$WD/gen.log" \
+    && ok "打印续跑提示" || bad "打印续跑提示"
+grep -q -- '--ref-silent-video out/segment_0002.mp4' "$LOG" \
+    && ok "续跑段以最后有效片段为参考" || bad "续跑段以最后有效片段为参考"
+[ -f "$WD/out/segment_0003.mp4" ] \
+    && bad "被中断的 segment_0003（已写入损坏文件）应被删除" \
+    || ok "被中断的 segment_0003（已写入损坏文件）已删除"
+
+printf '%s\n' "== 7. generate_series.sh：EXTRA_ARGS 校验 =="
+
+# --core-reuse 强制 --reuse 1；--seed 透传
+WD="$TMP/extra"; mkdir -p "$WD/out"; printf 'fake-png' > "$WD/start.png"
+make_mock_h3 "$WD"; cp "$GS" "$WD/"
+LOG="$WD/h3.log"
+run_gen "$WD" extra 40 \
+    MOCK_DELAY_FROM=3 MOCK_DELAY=30 MOCK_LOG="$LOG" \
+    -- -i start.png -d out -p "PROMPT" --reuse 2 --core-reuse 4 --seed 7 \
+    --steps 2 --frames 5
+wait_file "$WD/out/segment_0001.mp4" 20 || bad "--core-reuse 场景 segment_0001 未生成"
+sleep 1
+: > "$TMP/extra.trigger"
+wait_gen extra 25
+
+grep -q '已强制 --reuse 1' "$WD/gen.log" \
+    && ok "透传 --core-reuse 时打印强制提示" || bad "透传 --core-reuse 时打印强制提示"
+grep -q -- '--reuse 1' "$LOG" \
+    && ok "--core-reuse 透传时命令中使用 --reuse 1" || bad "--core-reuse 透传时命令中使用 --reuse 1"
+grep -q -- '--seed 7' "$LOG" \
+    && ok "--seed 7 原样透传" || bad "--seed 7 原样透传"
+
+# EXTRA_ARGS 中不允许 -o
+WD="$TMP/outflag"; mkdir -p "$WD/out"; printf 'fake-png' > "$WD/start.png"
+make_mock_h3 "$WD"; cp "$GS" "$WD/"
+out="$(cd "$WD" && bash ./generate_series.sh -i start.png -d out -p "PROMPT" -o /tmp/evil.mp4 2>&1)" || true
+printf '%s' "$out" | grep -q '不允许出现 -o/--output' \
+    && ok "EXTRA_ARGS 含 -o 时报错" || bad "EXTRA_ARGS 含 -o 时报错"
+
+printf '%s\n' "== 8. concat_segments.sh：拼接 =="
+
+WD="$TMP/concat"; mkdir -p "$WD/out"
+mkseg "$WD/out/segment_0001.mp4"
+mkseg "$WD/out/segment_0002.mp4"
+printf 'corrupt-garbage' > "$WD/out/segment_0003.mp4"
+mkseg "$WD/out/segment_0004.mp4"
+cp "$CS" "$WD/"
+
+outlog="$WD/concat.log"
+bash "$CS" "$WD/out" "$WD/final.mp4" > "$outlog" 2>&1
+if [ -f "$WD/final.mp4" ]; then
+    ok "默认模式拼接成功"
+    d="$(dur "$WD/final.mp4")"
+    if approx "$d" 0.3 0.08; then
+        ok "输出时长约等于 3 个有效片段之和（$d s）"
+    else
+        bad "输出时长约等于片段之和（$d s）"
+    fi
+    grep -q '模式：-c copy' "$outlog" && ok "默认模式提示 -c copy" || bad "默认模式提示 -c copy"
+    grep -q '警告：跳过损坏的片段' "$outlog" \
+        && ok "跳过损坏片段并打印警告" || bad "跳过损坏片段并打印警告"
+else
+    bad "默认模式拼接成功"
+fi
+
+bash "$CS" -r "$WD/out" "$WD/final_r.mp4" > "$outlog" 2>&1
+if [ -f "$WD/final_r.mp4" ]; then
+    ok "重编码模式拼接成功"
+    d="$(dur "$WD/final_r.mp4")"
+    approx "$d" 0.3 0.08 \
+        && ok "重编码输出时长正确（$d s）" || bad "重编码输出时长正确（$d s）"
+else
+    bad "重编码模式拼接成功"
+fi
+
+# 无有效片段 → 报错
+bash "$CS" "$WD/empty" "$WD/empty.mp4" >/dev/null 2>&1
+[ "$?" -ne 0 ] && ok "目录不存在时报错" || bad "目录不存在时报错"
+mkdir -p "$WD/onlybad"
+printf 'garbage' > "$WD/onlybad/segment_0001.mp4"
+bash "$CS" "$WD/onlybad" "$WD/bad.mp4" >/dev/null 2>&1
+[ "$?" -ne 0 ] && ok "只有损坏片段时报错" || bad "只有损坏片段时报错"
+
+printf '\n通过 %d 项，失败 %d 项\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## 方案
按 `plans/continuous-generation.md` 实施两个零外部依赖的 bash 脚本，包装 h3 的 first-frame 锚定 / ref-silent-video 延续链路。

## 变更
- **`generate_series.sh`**：从起始图持续生成 15 秒片段（`segment_%04d.mp4` 递增），Ctrl+C 干净退出并保留已完成片段；每段双重校验（h3 退出码 + ffprobe），失败按 `-r` 重试后中止；支持中断后续跑（启动扫描损坏段、next=最大有效编号+1）；EXTRA_ARGS 原样透传（拒绝 `-o`，`--core-reuse` 强制 `--reuse 1`）。
- **`concat_segments.sh`**：按字典序拼接 `segment_*.mp4`，默认 `-c copy` 无损，`-r` 重编码兜底（libx264+aac）；逐段 ffprobe 校验跳过损坏段并警告；失败删除不完整输出。
- **`tests/test_continuous_generation.sh`**（52 项断言）+ **`tests/sigint_helper.py`**：用 mock h3 + python fork（绕过后台 shell 忽略 SIGINT）覆盖生成/中断/重试/续跑/透传/concat 各路径。

## 兼容性
- bash 3.2.57（macOS 默认）兼容：手写参数解析，`${var}` 包裹全角字符后的展开（规避 bash 3.2 多字节标识符 bug）。
- 工具链仅 `./h3`、`ffmpeg`、`ffprobe`。