### PR TITLE
Distilled 5-6 step sampling via folded Turbo LoRA, plus three fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,45 @@ Standalone audio must accompany an image or video reference. Audio references
 must be 2–15 seconds; at most three audio inputs are accepted and their total
 decoded duration is capped at 15 seconds.
 
+## Distilled sampling: fold the Turbo LoRA into the checkpoint
+
+h3.c does not implement a LoRA runtime; step-distillation adapters can instead
+be folded into the checkpoint before inference. `tools/fold_turbo_lora.py`
+applies
+[larryvrh/MiniMax-H3-Turbo-Lora](https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora)
+directly to the bf16 shards. The adapter file,
+`minimax_h3_turbo_v4_step600_ema.safetensors`, is Apache-2.0 and remains subject
+to the MiniMax H3 Community License as a derivative. The tool clones the
+original shards and patches only the affected byte ranges. The headers and
+tensor order remain unchanged, as does their alignment:
+
+```sh
+python3 tools/fold_turbo_lora.py \
+  --checkpoint ./MiniMax-H3/FL2VA/transformer \
+  --lora ./minimax_h3_turbo_v4_step600_ema.safetensors \
+  --out ./MiniMax-H3-turbo/FL2VA/transformer
+```
+
+Point `-d` at a model directory whose `FL2VA/transformer` contains the folded
+tree; everything else can be symlinked to the original snapshot. Sample with
+`--steps 5` or `--steps 6` and no other speed flags. The distilled schedule
+removes the redundancy used by `--reuse` and `--core-reuse`, so neither option
+should be combined with it. On fast action, 4 steps showed motion smear; 5 is
+the validated floor.
+
+Cold single-shot measurements on an M5 Max used 960x544 and an identical prompt
+and seed. The comparison is against the tutorial's
+`--steps 20 --reuse 2 --layers 45` preset:
+
+| | balanced preset | folded turbo, 6 steps |
+|---|---:|---:|
+| 39 frames | 87s | 65s |
+| 124-frame (5 s) clip | 8.8min | 6.2min |
+
+On the clips tested, quality at 5-6 steps was comparable to the balanced preset,
+with sharper fine detail as the adapter's card advertises. An interactive
+session also amortizes transformer loading and text encoding across renders.
+
 ## Tests and runtime requirements
 
 ```sh

--- a/h3_gpu.m
+++ b/h3_gpu.m
@@ -7,6 +7,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <mach-o/dyld.h>
 #include <limits.h>
 #include <math.h>
 #include <stdarg.h>
@@ -353,6 +354,23 @@ h3_gpu *h3_gpu_create(const char *shader_source_path,
         const char *source_path = shader_source_path ? shader_source_path :
                                                        "h3_shaders.metal";
         NSString *path = [NSString stringWithUTF8String:source_path];
+        /* A relative shader path that does not exist in the current directory
+         * falls back to the executable's directory, so the binary can be
+         * launched from anywhere (daemons, PATH installs, other projects). */
+        if (![path isAbsolutePath] &&
+            ![[NSFileManager defaultManager] fileExistsAtPath:path]) {
+            uint32_t exe_size = 0;
+            _NSGetExecutablePath(NULL, &exe_size);
+            char *exe_buf = malloc(exe_size);
+            if (exe_buf && _NSGetExecutablePath(exe_buf, &exe_size) == 0) {
+                NSString *exe = [NSString stringWithUTF8String:exe_buf];
+                NSString *beside = [[exe stringByDeletingLastPathComponent]
+                    stringByAppendingPathComponent:path];
+                if ([[NSFileManager defaultManager] fileExistsAtPath:beside])
+                    path = beside;
+            }
+            free(exe_buf);
+        }
         NSError *libraryError = nil;
         NSString *source = [NSString stringWithContentsOfFile:path
                                                      encoding:NSUTF8StringEncoding

--- a/h3_safetensors.c
+++ b/h3_safetensors.c
@@ -389,6 +389,22 @@ int h3_st_read_header(const char *path, h3_st_header *header,
         close(descriptor);
         return 0;
     }
+    /* The GPU path maps tensors in place, which requires the data section
+     * (8 + header bytes) to start 8-byte aligned. Writers that do not pad
+     * the JSON header (for example MLX's save_safetensors) produce files
+     * that are valid per the format spec but silently decode to garbage
+     * here, rendering black video. Refuse them with an actionable message
+     * instead. Repro: pad the same file's header with spaces to the next
+     * 8-byte boundary and it renders correctly. */
+    if ((8 + header_size) % 8 != 0) {
+        if (error && error_size)
+            snprintf(error, error_size,
+                     "%s: data section starts misaligned (8 + %llu-byte header); "
+                     "re-save with the JSON header padded to an 8-byte boundary",
+                     path, (unsigned long long)header_size);
+        close(descriptor);
+        return 0;
+    }
     char *json = malloc((size_t)header_size + 1);
     if (!json || pread(descriptor, json, (size_t)header_size, 8) != (ssize_t)header_size) {
         if (error && error_size) snprintf(error, error_size, "%s: cannot read header", path);

--- a/h3_video_vae.c
+++ b/h3_video_vae.c
@@ -668,7 +668,10 @@ static int configured_tile_pixels(int pixel_height, int pixel_width) {
     if (value && *value) {
         char *end = NULL;
         long pixels = strtol(value, &end, 10);
-        if (end && !*end && pixels >= TILE_PIXELS && pixels <= 512 &&
+        /* Cap at 320 to match the automatic search: tiles above 320 pixels
+         * produce a visible grid/quilt artifact across the whole frame
+         * (reproduced at 512 and 1088 on M5 Max). */
+        if (end && !*end && pixels >= TILE_PIXELS && pixels <= 320 &&
             pixels % SPATIAL_RATIO == 0) return (int)pixels;
     }
     int best = TILE_PIXELS;

--- a/tools/fold_turbo_lora.py
+++ b/tools/fold_turbo_lora.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Fold a MiniMax-H3 LoRA into the bf16 checkpoint by in-place byte patching.
+
+h3.c has no LoRA runtime, and does not need one: a LoRA is W' = W + scale*(B@A),
+which can be baked into the checkpoint once, offline. This tool clones the
+original shards (copy-on-write where the filesystem supports it) and rewrites
+only the byte ranges of the targeted tensors, so headers, tensor order, and
+alignment stay byte-identical to the originals.
+
+Folding the 4-step Turbo distillation adapter this way enables 5-6 step
+sampling at zero runtime cost. Measured on an M5 Max (960x544, identical
+prompt/seed): 39 frames 87s -> 65s and a 5s clip 8.8min -> 6.2min versus the
+--steps 20 --reuse 2 --layers 45 preset, at comparable visual quality.
+
+Requires only numpy. Adapter tensors must be named <target>.lora_A.weight /
+<target>.lora_B.weight over the checkpoint's own key space, as
+larryvrh/MiniMax-H3-Turbo-Lora's packaged .safetensors files are.
+
+Usage:
+  python3 tools/fold_turbo_lora.py \
+      --checkpoint MiniMax-H3/FL2VA/transformer \
+      --lora minimax_h3_turbo_v4_step600_ema.safetensors \
+      --out MiniMax-H3-turbo/FL2VA/transformer
+Then point h3 at a model directory whose transformer is the folded tree and
+sample with --steps 5 or 6 (4 shows motion smear; do not combine with --reuse).
+"""
+import argparse
+import json
+import shutil
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def read_header(path):
+    with open(path, "rb") as f:
+        (hlen,) = struct.unpack("<Q", f.read(8))
+        header = json.loads(f.read(hlen))
+    header.pop("__metadata__", None)
+    return hlen, header
+
+
+def load_tensor(path, info, base):
+    start, end = info["data_offsets"]
+    dtype = info["dtype"]
+    with open(path, "rb") as f:
+        f.seek(base + start)
+        raw = f.read(end - start)
+    if dtype == "BF16":
+        u16 = np.frombuffer(raw, dtype="<u2").astype(np.uint32)
+        return (u16 << 16).view(np.float32).reshape(info["shape"])
+    if dtype == "F32":
+        return np.frombuffer(raw, dtype="<f4").reshape(info["shape"]).copy()
+    raise SystemExit(f"unsupported dtype {dtype} for {path}")
+
+
+def f32_to_bf16_bytes(x):
+    u32 = np.ascontiguousarray(x, dtype=np.float32).view(np.uint32)
+    rounded = (u32 + 0x7FFF + ((u32 >> 16) & 1)) >> 16  # round to nearest even
+    return rounded.astype("<u2").tobytes()
+
+
+def clone(src, dst):
+    if subprocess.run(["cp", "-c", str(src), str(dst)],
+                      capture_output=True).returncode != 0:
+        shutil.copy2(src, dst)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--checkpoint", required=True, type=Path,
+                    help="directory of original bf16 transformer shards")
+    ap.add_argument("--lora", required=True, type=Path,
+                    help="LoRA .safetensors with <key>.lora_A/.lora_B pairs")
+    ap.add_argument("--out", required=True, type=Path,
+                    help="output directory for the folded shards")
+    ap.add_argument("--scale", type=float, default=1.0)
+    args = ap.parse_args()
+
+    lhl, lora_hdr = read_header(args.lora)
+    lora_base = 8 + lhl
+    pairs = {}
+    for key in lora_hdr:
+        if key.endswith(".lora_A.weight"):
+            target = key[: -len(".lora_A.weight")] + ".weight"
+            pairs[target] = (key, key[: -len(".lora_A.weight")] + ".lora_B.weight")
+    if not pairs:
+        raise SystemExit("no .lora_A/.lora_B pairs found in the adapter")
+    print(f"{len(pairs)} adapter pairs")
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    shards = sorted(args.checkpoint.glob("model-*.safetensors"))
+    if not shards:
+        raise SystemExit(f"no shards in {args.checkpoint}")
+    for extra in ("config.json", "model.safetensors.index.json"):
+        src = args.checkpoint / extra
+        if src.exists():
+            shutil.copy2(src, args.out / extra)
+
+    patched = 0
+    for shard in shards:
+        dst = args.out / shard.name
+        clone(shard, dst)
+        hlen, hdr = read_header(dst)
+        base = 8 + hlen
+        todo = [k for k in hdr if k in pairs]
+        if not todo:
+            continue
+        with open(dst, "r+b") as f:
+            for key in todo:
+                info = hdr[key]
+                if info["dtype"] != "BF16":
+                    raise SystemExit(f"{key}: expected BF16, got {info['dtype']}")
+                a_key, b_key = pairs[key]
+                A = load_tensor(args.lora, lora_hdr[a_key], lora_base)
+                B = load_tensor(args.lora, lora_hdr[b_key], lora_base)
+                W = load_tensor(dst, info, base)
+                folded = W + args.scale * (B.astype(np.float32) @ A.astype(np.float32))
+                # parity check on a random probe before committing bytes
+                x = np.random.default_rng(0).standard_normal(W.shape[1]).astype(np.float32)
+                direct = folded @ x
+                composed = W @ x + args.scale * (B @ (A @ x))
+                rel = np.max(np.abs(direct - composed)) / (np.max(np.abs(composed)) + 1e-9)
+                if rel > 1e-4:
+                    raise SystemExit(f"{key}: parity check failed (rel={rel:.2e})")
+                buf = f32_to_bf16_bytes(folded)
+                start, end = info["data_offsets"]
+                if len(buf) != end - start:
+                    raise SystemExit(f"{key}: byte count mismatch")
+                f.seek(base + start)
+                f.write(buf)
+                patched += 1
+        print(f"{shard.name}: cumulative {patched}/{len(pairs)}")
+
+    if patched != len(pairs):
+        raise SystemExit(f"only {patched} of {len(pairs)} adapter pairs matched "
+                         "checkpoint tensors - wrong checkpoint or adapter?")
+    print("done")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR adds LoRA support to h3 by folding adapters into the bf16 checkpoint
offline, without adding a LoRA runtime. With the community Turbo distillation
adapter folded, the existing 5-6 step mode becomes usable at final quality
instead of serving as a preview mode, and runs ~1.35x faster than the balanced
preset. The README measures stock low-step sampling at 0.556 SSIM against the
reference. The folding code is adapter-agnostic, allowing use with the wider
LoRA ecosystem.
It handles style adapters and sequential folds, and it can be used for future
distillations. On APFS, each folded variant uses ~2-3 GB of real disk. The PR
also contains three small fixes found while running h3 on large real workloads;
I am happy to split them into separate PRs if preferred.

## tools/fold_turbo_lora.py

`tools/fold_turbo_lora.py` applies `W' = W + scale*(B@A)` to the shards offline.
It clones the original files, using copy-on-write where the filesystem supports
it, and rewrites only the affected byte ranges. The headers and tensor order
remain byte-identical, as does the alignment. The implementation is pure numpy
and runs a per-tensor parity probe before writing any bytes.

For a checkpoint folded with larryvrh's Turbo v4 adapter (Apache-2.0), h3 uses
`--steps 5` or `6` without other speed flags. Cold single-shot measurements on
an M5 Max at 960x544 used the same prompt and seed, with the tutorial's balanced
preset (`--steps 20 --reuse 2 --layers 45`) as the comparison:

| | balanced preset | folded turbo, 6 steps |
|---|---:|---:|
| 39 frames | 87s | 65s |
| 124-frame (5 s) clip | 8.8min | 6.2min |

Visual quality was comparable on the clips tested, although fast action showed
motion smear at 4 steps. The README therefore documents 5 as the floor and warns
against combining the distilled schedule with `--reuse` or `--core-reuse`, since
that schedule removes the redundancy used by both options.

## Fixes

### Relative shader lookup

A relative shader path is now resolved against the executable's directory when
the file is absent from the CWD. Previously, `h3` failed with "cannot compile
h3_shaders.metal" unless it was launched from the source directory.

### Misaligned safetensors

Files whose data section offset, 8 + header bytes, is not 8-byte aligned are now
rejected with an actionable message. Such files are spec-valid, but they
silently decode to garbage in h3, producing black video with intact audio.
MLX's `save_safetensors` can write these files because it does not pad the JSON
header. Round-tripping a checkpoint verified that the unpadded file renders
black, while the same file renders correctly after its header is padded to the
next 8-byte boundary without changing tensor order. Accepting these files would
be the proper fix; rejecting them explicitly is a first step.

### VAE tile limit

`H3_VAE_TILE_PIXELS` is now clamped to 320 to match the automatic search. Tiles
above 320 produce a grid/quilt artifact across the whole frame. This was
reproduced at 512 and 1088 on an M5 Max at 960x544.

All measurements were made on a MacBook Pro with an M5 Max 128 GB configuration
running macOS 26.5. The MiniMax H3 Community License's territorial restrictions
apply to the weights and, under its terms, to the adapter as a derivative.
