### PR TITLE
ffmpeg: tolerate trailing CSV separator from side-data streams (iPhone .mov)

### DIFF
--- a/h3_ffmpeg.c
+++ b/h3_ffmpeg.c
@@ -133,12 +133,20 @@ int h3_ffprobe_visual_size(const char *path, int *width, int *height,
              path);
         return 0;
     }
-    for (char *cursor = output + consumed; *cursor; cursor++) {
-        if (*cursor != ' ' && *cursor != '\t' && *cursor != '\r' &&
-            *cursor != '\n') {
-            fail(error, error_size, "FFprobe returned an invalid visual size");
-            return 0;
-        }
+    /* FFprobe's compact/CSV writer (FFmpeg >= 5.1) emits one item
+     * separator before an unselected nested stream side_data_list —
+     * present in e.g. iPhone .mov files carrying a display matrix —
+     * yielding "3840x2160x". Accept exactly that one optional separator
+     * before trailing whitespace; anything else is still an error. */
+    char *cursor = output + consumed;
+    if (*cursor == 'x') cursor++;
+    while (*cursor == ' ' || *cursor == '\t' || *cursor == '\r' ||
+           *cursor == '\n') {
+        cursor++;
+    }
+    if (*cursor != '\0') {
+        fail(error, error_size, "FFprobe returned an invalid visual size");
+        return 0;
     }
     if (parsed_width < 1 || parsed_height < 1) {
         fail(error, error_size, "visual stream has invalid dimensions %dx%d",


### PR DESCRIPTION
h3_ffprobe_visual_size() runs `ffprobe ... -of csv=p=0:s=x` and rejects any non-whitespace after the parsed WxH. For streams carrying side data — e.g. the display-matrix side data present in every iPhone-shot .mov — ffprobe's CSV writer appends a trailing field separator, so the output is `3840x2160x` and the probe fails with "FFprobe returned an invalid visual size" on files that are perfectly valid inputs.

Repro: `ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of csv=p=0:s=x IMG_xxxx.mov` on any iPhone clip → `3840x2160x`.

Fix: tolerate stray separator characters (and whitespace) after the parsed size; anything else is still rejected, and the width/height sanity checks below are unchanged. Verified against the failing .mov (now parses 3840x2160) and a plain jpeg (unchanged, 1408x1408).

🤖 Generated with [Claude Code](https://claude.com/claude-code)