### PR TITLE
docs: fix grammar - "the name of the authors" should be "the names of the authors"

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -16,7 +16,7 @@ modification, are permitted provided that the following conditions are met:
 - Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
-- Neither the name of the authors nor the names of its contributors may be
+- Neither the names of the authors nor the names of its contributors may be
   used to endorse or promote products derived from this software without
   specific prior written permission.
 


### PR DESCRIPTION
## Description

This PR fixes a minor grammar error in the THIRD_PARTY_NOTICES.md file.

## Problem

On line 19 of `THIRD_PARTY_NOTICES.md`:

```markdown
Neither the name of the authors nor the names of its contributors may be
```

Singular "name" is used with plural "authors", creating a noun-number agreement error.

## Fix

Changed "the name of the authors" to "the names of the authors":
```markdown
Neither the names of the authors nor the names of its contributors may be
```

## Type of change

- [x] Documentation fix (grammar)