### PR TITLE
Align causal GQA threadgroup memory length to 16 bytes

### DIFF
--- a/h3_gpu.m
+++ b/h3_gpu.m
@@ -4286,7 +4286,9 @@ int h3_gpu_gqa_causal_bf16(h3_gpu *opaque, h3_gpu_tensor *output,
     if (getenv("H3_MPS_GQA") && h3_gpu_gqa_mps(
             gpu, output, query, key, value, sequence, query_heads,
             kv_heads, head_dim, scale)) return 1;
-    size_t score_bytes = (size_t)sequence * sizeof(float);
+    /* Metal requires threadgroup memory lengths to be 16-byte multiples;
+     * the API validation layer aborts on unaligned lengths. */
+    size_t score_bytes = ((size_t)sequence * sizeof(float) + 15) & ~(size_t)15;
     id<MTLComputePipelineState> pipeline = h3_gpu_pipeline(gpu,
                                                            @"h3_gqa_causal_bf16");
     if (!pipeline) return 0;


### PR DESCRIPTION
`setThreadgroupMemoryLength` requires the length to be a multiple of 16 bytes, but `h3_gpu_gqa_causal_bf16` sizes the causal score buffer as `sequence * sizeof(float)` — out of spec whenever the prompt's token count is not a multiple of 4.

The driver tolerates this silently, so ordinary runs work. But with the Metal API validation layer active (`MTL_DEBUG_LAYER=1` — which any child process inherits from an Xcode-launched app with default scheme diagnostics), the first text encoder dispatch aborts:

```
-[MTLDebugComputeCommandEncoder setThreadgroupMemoryLength:atIndex:]:799:
failed assertion `length(140) must be a multiple of 16 bytes.'
```

(140 bytes = a 35-token prompt.)

## Fix

Round the threadgroup memory length up to the next 16-byte multiple. The kernel never reads the padding, and the rounding happens before the `maxThreadgroupMemoryLength` capacity check so that check stays accurate. Behavior for already-aligned sequence lengths is unchanged.

## Verification

The bundled `h3_text_tests` can't catch this — its fixture sequence length of 32 is already a multiple of 4. I verified with a minimal fixture-free repro calling `h3_gpu_gqa_causal_bf16` at sequence 35 (synthetic bf16 tensors, same head geometry as the Qwen text encoder):

- pre-fix, `MTL_DEBUG_LAYER=1`: aborts with the exact assertion above (SIGABRT)
- post-fix, `MTL_DEBUG_LAYER=1`: passes, all outputs finite
- post-fix, no validation: passes — no change for normal runs

Happy to add the repro as a test if you'd like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)